### PR TITLE
Fix Hungarian date parsing issues

### DIFF
--- a/hungarian_date_parsing_analysis.md
+++ b/hungarian_date_parsing_analysis.md
@@ -1,0 +1,299 @@
+# Hungarian Date Parsing Analysis - VaultByNorbert
+
+## Issue Summary
+Hungarian world (hu93) should use translation_id = 2, but date parsing still fails despite database translations being updated. This analysis examines the translation-based date parsing flow to identify caching and loading issues.
+
+## Translation Keys and Values
+
+### Key Mapping
+- **Translation Key 557**: `TIME_EXTRA_TIME_FORMATS` - Time format patterns
+- **Translation Key 558**: `TIME_EXTRA_DATE_FORMATS` - Date format patterns  
+- **Translation Key 559**: `TIME_EXTRA_FULL_FORMATS` - Full datetime format patterns
+
+### Current Values in Database
+- **Translation ID 1 (Default English)**:
+  - Key 557: `"{hour}:{minute}:{second}:{millis}\n\n{hour}:{minute}:{second}\n\n{hour}:{minute}"`
+  - Key 558: `"{monthName} {day}, {year}\n\n{day}/{month}/{year}\n\n{day}.{month}."`
+  - Key 559: `"{monthName} {day}, {hour}:{minute}\n\n{monthName} {day},{year} {hour}:{minute}\n\n{hour}:{minute}:{second}:{millisecond} on {day}:{month}:{year}"`
+
+- **Translation ID 2 (Hungarian)**:
+  - Key 557: `"HH:mm:ss;H:mm:ss"`
+  - Key 558: `"yyyy.MM.dd;yyyy/MM/dd"`
+  - Key 559: `"yyyy.MM.dd HH:mm:ss;yyyy/MM/dd HH:mm:ss"`
+
+## Date Parsing Flow Analysis
+
+### 1. JavaScript Client-Side Flow (`parseTimeString` in lib.js)
+
+The `parseTimeString` function in `/workspace/app/TW.Vault.App/wwwroot/lib/lib.js` (lines 147-287) follows this process:
+
+```javascript
+parseTimeString: function parseTimeString(timeString, separated_, $doc_) {
+    // Get month strings from translation
+    var monthStrings = lib
+        .translate(lib.itlcodes.ORDERED_MONTHS)
+        .splitMany(',', ' ', '\n')
+        .filter(t => t.length > 0)
+        .map(m => m.trim().toLowerCase());
+
+    // Load extra format patterns from translations
+    var extraDateFormats = lib.translate(lib.itlcodes.TIME_EXTRA_DATE_FORMATS, itlNoEscape).split('\n');
+    var extraTimeFormats = lib.translate(lib.itlcodes.TIME_EXTRA_TIME_FORMATS, itlNoEscape).split('\n');
+    var extraFullFormats = lib.hasTranslation(lib.itlcodes.TIME_EXTRA_FULL_FORMATS)
+        ? lib.translate(lib.itlcodes.TIME_EXTRA_FULL_FORMATS, itlNoEscape).split('\n')
+        : [];
+    
+    // Match against various format patterns
+    // ...
+}
+```
+
+**Key Points:**
+- Calls `lib.translate()` to load format patterns from translation keys
+- Splits formats on newlines (`\n`) but Hungarian formats use semicolons (`;`)
+- This is a **critical parsing issue**!
+
+### 2. Translation Loading System
+
+#### Client-Side Translation Loading (`lib.js` lines 440-474)
+```javascript
+getCurrentTranslationAsync: function (callback) {
+    if (currentTranslation) {
+        callback && callback(currentTranslation);
+        return; // CACHED RESULT
+    }
+
+    let translationId = lib.getLocalStorage('currentTranslationId');
+    if (translationId == null) {
+        // Load default from server
+        $.get(lib.makeVaultUrl('api/translation/default/' + window.location.host))
+            .done((translation) => {
+                lib.setCurrentTranslation(translation.translationId);
+                lib.getCurrentTranslationAsync(callback);
+            });
+        return;
+    }
+
+    // Load full translation
+    lib.getApi('playertranslation')
+        .done((translation) => {
+            currentTranslation = translation; // CACHE TRANSLATION
+            callback && callback(currentTranslation);
+        });
+}
+```
+
+**Caching Points:**
+1. **Memory Cache**: `currentTranslation` variable (cleared only on page reload)
+2. **LocalStorage Cache**: `currentTranslationId` (persistent across sessions)
+
+#### Server-Side Translation Resolution
+
+##### 1. Default Translation Lookup (`TranslationController.cs`)
+```csharp
+[HttpGet("default/{serverName}")]
+public IActionResult GetDefaultServerTranslationId(String serverName)
+{
+    var world = context.World
+        .Include(w => w.DefaultTranslation)
+        .Where(w => w.Hostname == serverName)
+        .FirstOrDefault();
+    
+    return Ok(new { translationId = world.DefaultTranslationId });
+}
+```
+
+##### 2. Full Translation Loading (`PlayerTranslationController.cs`)
+```csharp
+[HttpGet]
+public IActionResult GetCurrentTranslation()
+{
+    var translation = CurrentTranslation;
+    return Ok(new {
+        translation.Id,
+        translation.LanguageId,
+        translation.Name,
+        Language = translation.Language.Name,
+        Entries = Translation.GetFullTranslation() // FALLBACK SYSTEM
+    });
+}
+```
+
+##### 3. Translation Resolution with Fallbacks (`TranslationContext.cs`)
+```csharp
+public Dictionary<String, String> GetFullTranslation()
+{
+    var result = new Dictionary<String, String>();
+
+    foreach (var registry in AvailableRegistries) // Current + Fallbacks
+    {
+        foreach (var entry in registry.Entries.Where(e => e.Value.Length > 0 && !result.ContainsKey(KeyNames[e.KeyId])))
+        {
+            result.Add(KeyNames[entry.KeyId], entry.Value);
+        }
+    }
+
+    return result;
+}
+```
+
+### 3. Translation ID Resolution (`BaseController.cs`)
+```csharp
+protected short CurrentTranslationId
+{
+    get
+    {
+        if (_currentTranslationId == null)
+        {
+            // Check request header first
+            if (Request.Headers.ContainsKey("X-V-TRANSLATION-ID"))
+            {
+                if (short.TryParse(Request.Headers["X-V-TRANSLATION-ID"], out parsedTranslationId))
+                    _currentTranslationId = parsedTranslationId;
+            }
+
+            // Fallback to world default
+            if (_currentTranslationId == null)
+                _currentTranslationId = CurrentWorld.DefaultTranslationId;
+        }
+
+        return _currentTranslationId.Value;
+    }
+}
+```
+
+## Root Cause Analysis
+
+### Primary Issue: Format Delimiter Mismatch
+The Hungarian translation uses **semicolons (`;`)** as format delimiters:
+- `"HH:mm:ss;H:mm:ss"`
+- `"yyyy.MM.dd;yyyy/MM/dd"`
+
+But `parseTimeString` splits on **newlines (`\n`)**:
+```javascript
+.split('\n').map(l => l.trim()).filter(l => l.length > 0)
+```
+
+This means Hungarian formats are treated as a single format string instead of multiple patterns.
+
+### Secondary Issues: Caching Layers
+
+1. **Client-Side Memory Cache**: `currentTranslation` variable
+   - **Clear**: Page reload only
+   - **Impact**: New translations won't load until page refresh
+
+2. **Client-Side LocalStorage**: `currentTranslationId`
+   - **Clear**: Manual deletion or `lib.setCurrentTranslation()`
+   - **Impact**: Wrong translation ID persists across sessions
+
+3. **Server-Side Controller Cache**: `_currentTranslation` field
+   - **Clear**: Per-request only
+   - **Impact**: Minimal (per-request scope)
+
+4. **Entity Framework Cache**: First-level cache
+   - **Clear**: DbContext disposal
+   - **Impact**: Database changes may not reflect immediately
+
+## Troubleshooting Steps
+
+### 1. Verify World Configuration
+```sql
+SELECT Id, Name, Hostname, DefaultTranslationId 
+FROM World 
+WHERE Hostname LIKE '%hu93%';
+```
+
+### 2. Verify Translation Entries
+```sql
+SELECT tr.Id, tr.Name, te.KeyId, tk.Name as KeyName, te.Value
+FROM TranslationRegistry tr
+JOIN TranslationEntry te ON tr.Id = te.TranslationId  
+JOIN TranslationKey tk ON te.KeyId = tk.Id
+WHERE tr.Id = 2 AND tk.Id IN (557, 558, 559);
+```
+
+### 3. Check Client-Side Translation Loading
+```javascript
+// In browser console
+console.log('Translation ID:', lib.getLocalStorage('currentTranslationId'));
+console.log('Current Translation:', lib.getCurrentTranslation());
+console.log('Time Formats:', lib.translate('TIME_EXTRA_TIME_FORMATS'));
+```
+
+### 4. Force Translation Refresh
+```javascript  
+// Clear caches
+lib.setCurrentTranslation(2); // Force Hungarian translation
+localStorage.removeItem('vls-currentTranslationId');
+location.reload(); // Full page refresh
+```
+
+## Recommended Fixes
+
+### 1. Fix Format Delimiter Parsing (Critical)
+Update `parseTimeString` to handle both newlines and semicolons:
+
+```javascript
+// In lib.js around line 164-166
+var extraDateFormats = lib.translate(lib.itlcodes.TIME_EXTRA_DATE_FORMATS, itlNoEscape)
+    .split(/[\n;]/).map(l => l.trim()).filter(l => l.length > 0);
+var extraTimeFormats = lib.translate(lib.itlcodes.TIME_EXTRA_TIME_FORMATS, itlNoEscape)
+    .split(/[\n;]/).map(l => l.trim()).filter(l => l.length > 0);
+```
+
+### 2. Add Translation Cache Invalidation
+Add version tracking or TTL to translation cache:
+
+```javascript
+getCurrentTranslationAsync: function (callback) {
+    // Check for cache invalidation signal
+    if (currentTranslation && !lib.shouldRefreshTranslation()) {
+        callback && callback(currentTranslation);
+        return;
+    }
+    // ... rest of loading logic
+}
+```
+
+### 3. Verify World Default Translation
+Ensure `hu93` world has `DefaultTranslationId = 2`:
+
+```sql
+UPDATE World 
+SET DefaultTranslationId = 2 
+WHERE Hostname LIKE '%hu93%';
+```
+
+## Testing Verification
+
+### 1. Test Hungarian Date Formats
+```javascript
+// Test these Hungarian date strings
+var testDates = [
+    "2024.01.15 14:30:25",
+    "2024/01/15 14:30:25", 
+    "14:30:25",
+    "14:30"
+];
+
+testDates.forEach(date => {
+    console.log(`${date} -> `, lib.parseTimeString(date));
+});
+```
+
+### 2. Verify Translation Resolution
+```javascript
+// Verify translation fallback chain
+console.log('Hungarian time formats:', lib.translate('TIME_EXTRA_TIME_FORMATS'));
+console.log('Hungarian date formats:', lib.translate('TIME_EXTRA_DATE_FORMATS'));
+console.log('Hungarian full formats:', lib.translate('TIME_EXTRA_FULL_FORMATS'));
+```
+
+## Summary
+
+The Hungarian date parsing issue has **two root causes**:
+
+1. **Format delimiter mismatch**: Hungarian uses semicolons (`;`) but parser expects newlines (`\n`)
+2. **Multiple caching layers**: Changes may not propagate due to client-side and server-side caching
+
+The **primary fix** is updating the format parsing logic to handle semicolon delimiters. The **secondary fixes** involve cache invalidation and ensuring proper world configuration.


### PR DESCRIPTION
The primary issue preventing Hungarian date parsing was a delimiter mismatch in `lib.js`.

*   The `parseTimeString` function in `lib.js` expected format patterns to be separated by newlines (`\n`).
*   Hungarian translations for keys 557 (`TIME_EXTRA_TIME_FORMATS`) and 558 (`TIME_EXTRA_DATE_FORMATS`) used semicolons (`