### PR TITLE
Enable functionality on Hungarian servers

### DIFF
--- a/app/TW.Vault.App/wwwroot/lib/lib.js
+++ b/app/TW.Vault.App/wwwroot/lib/lib.js
@@ -1,5 +1,4 @@
-﻿
-var lib = (() => {
+﻿var lib = (() => {
 
     //# REQUIRE lib/twstats.js
     //# REQUIRE lib/twcalc.js
@@ -179,11 +178,11 @@ var lib = (() => {
 
             const itlNoEscape = { _escaped: false };
 
-            var extraDateFormats = lib.translate(lib.itlcodes.TIME_EXTRA_DATE_FORMATS, itlNoEscape).split('\n').map(l => l.trim()).filter(l => l.length > 0);
-            var extraTimeFormats = lib.translate(lib.itlcodes.TIME_EXTRA_TIME_FORMATS, itlNoEscape).split('\n').map(l => l.trim()).filter(l => l.length > 0);
+            var extraDateFormats = lib.translate(lib.itlcodes.TIME_EXTRA_DATE_FORMATS, itlNoEscape).split(/[\n;]/).map(l => l.trim()).filter(l => l.length > 0);
+            var extraTimeFormats = lib.translate(lib.itlcodes.TIME_EXTRA_TIME_FORMATS, itlNoEscape).split(/[\n;]/).map(l => l.trim()).filter(l => l.length > 0);
 
             var extraFullFormats = lib.hasTranslation(lib.itlcodes.TIME_EXTRA_FULL_FORMATS)
-                ? lib.translate(lib.itlcodes.TIME_EXTRA_FULL_FORMATS, itlNoEscape).split('\n').map(l => l.trim()).filter(l => l.length > 0)
+                ? lib.translate(lib.itlcodes.TIME_EXTRA_FULL_FORMATS, itlNoEscape).split(/[\n;]/).map(l => l.trim()).filter(l => l.length > 0)
                 : [];
 
             let extraDateTimePermutations = extraDateFormats.map(d => extraTimeFormats.map(t => ({ date: d, time: t }))).flat();


### PR DESCRIPTION
To enable full support for Hungarian servers, a critical fix was applied to the date and time parsing logic.

*   In `app/TW.Vault.App/wwwroot/lib/lib.js`, the string splitting mechanism for `extraDateFormats`, `extraTimeFormats`, and `extraFullFormats` was updated.
*   The previous `split('\n')` was changed to `split(/[\n